### PR TITLE
Inference

### DIFF
--- a/deadtrees/deployment/inference.py
+++ b/deadtrees/deployment/inference.py
@@ -1,0 +1,53 @@
+import io
+
+import numpy as np
+import torch
+from deadtrees.data.deadtreedata import val_transform
+from deadtrees.network.segmodel import SemSegment
+from matplotlib import cm
+from PIL import Image
+
+
+def get_model(model_path: str = "bestmodel.ckpt"):
+    model = SemSegment.load_from_checkpoint(model_path)
+    model.eval()
+    return model
+
+
+def split_image_into_tiles(image: Image):
+    # complete this: what about batches?
+    batch = val_transform(image=image)["image"]
+    return batch.unsqueeze(0)
+
+
+def get_segmentation(
+    model: SemSegment, binary_image: bytes, model_name: str = "unknown"
+):
+    image = Image.open(io.BytesIO(binary_image)).convert("RGB")
+
+    batch = split_image_into_tiles(np.array(image))
+
+    import time
+
+    start = time.process_time()
+
+    with torch.no_grad():
+        output = model(batch)
+
+    elapsed = time.process_time() - start
+
+    output_predictions = output.argmax(1)
+
+    image = Image.fromarray(np.uint8(output_predictions.squeeze() * 255), "L")
+    dead_tree_fraction = (
+        torch.count_nonzero(output_predictions) / torch.numel(output_predictions)
+    ).item()
+
+    return {
+        "image": image,
+        "stats": {
+            "fraction": str(dead_tree_fraction),
+            "model_name": model_name,
+            "elapsed": str(elapsed),
+        },
+    }

--- a/deadtrees/deployment/server.py
+++ b/deadtrees/deployment/server.py
@@ -1,0 +1,77 @@
+import io
+from typing import Any, Dict
+
+from fastapi import FastAPI, File
+from pydantic import BaseModel
+from starlette.responses import HTMLResponse, Response
+
+from deadtrees.deployment.inference import get_model, get_segmentation
+
+MODEL = "bestmodel.ckpt"
+
+model = get_model(MODEL)
+
+app = FastAPI(
+    title="DeadTrees image segmentation",
+    description="""Obtain semantic segmentation maps of the image in input via our UNet implemented in PyTorch.
+                           Visit this URL at port 8501 for the streamlit interface.""",
+    version="0.1.0",
+)
+
+
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+async def root():
+    return """\
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <!-- Required meta tags -->
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+            <!-- Bootstrap CSS -->
+            <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+
+            <title>DeadTrees Inference API</title>
+            <meta http-equiv="refresh" content="7; URL=./docs" />
+        </head>
+        <body>
+
+        <div class="d-flex vh-100">
+            <div class="d-flex w-100 justify-content-center align-self-center">
+                <div class="jumbotron">
+                    <h1 class="display-4">🌲☠️🌲🌲🌲 DeadTrees Inference API 🌲🌲☠️☠️🌲</h1>
+                    <p class="lead">REST API for semantic segmentation of dead trees from ortho photos</p>
+                    <hr class="my-4">
+                    <p>You will be redirected to the <a href="./docs"><b>OpenAPI documentation page</b></a> in 7 seconds...</p>
+                </div>
+            </div>
+        </div>
+
+        <!-- Optional JavaScript -->
+        <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+
+        </body>
+    </html>
+    """
+
+
+@app.post("/segmentation")  # , response_model=Prediction)
+def get_segmentation_map(file: bytes = File(...)):
+    """Get segmentation maps from image file"""
+
+    # return data dict, convert to pydantic model (?)
+    data = get_segmentation(model, file, model_name=MODEL)
+
+    bytes_io = io.BytesIO()
+    data["image"].save(bytes_io, format="PNG")
+
+    stats = {
+        "fraction": data["stats"]["fraction"],
+        "model_name": data["stats"]["model_name"],
+        "elapsed": data["stats"]["elapsed"],
+    }
+    return Response(bytes_io.getvalue(), headers=stats, media_type="image/png")

--- a/deadtrees/deployment/ui.py
+++ b/deadtrees/deployment/ui.py
@@ -1,0 +1,62 @@
+import io
+import textwrap
+
+import requests
+import streamlit as st
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+
+from PIL import Image
+
+# interact with FastAPI endpoint
+backend = "http://backend:8000/segmentation"
+
+
+def process(image, server_url: str):
+
+    m = MultipartEncoder(fields={"file": ("filename", image, "image/jpeg")})
+
+    r = requests.post(
+        server_url, data=m, headers={"Content-Type": m.content_type}, timeout=8000
+    )
+
+    return r
+
+
+# construct UI layout
+st.title("DeadTree image segmentation")
+
+st.write(
+    """Obtain semantic segmentation maps of the image in input via our UNet implemented in PyTorch.
+         Visit this URL at port 8501 for the streamlit interface."""
+)  # description and instructions
+
+
+input_image = st.file_uploader("insert image")  # image upload widget
+
+if st.button("Get segmentation map"):
+
+    col1, col2 = st.beta_columns(2)
+
+    if input_image:
+        segments = process(input_image, backend)
+        original_image = Image.open(input_image).convert("RGB")
+        segmented_image = Image.open(io.BytesIO(segments.content)).convert("RGB")
+        col1.header("Original")
+        col1.image(original_image, use_column_width=True)
+        col2.header("Segmented")
+        col2.image(segmented_image, use_column_width=True)
+
+        d = segments.headers
+        st.markdown(
+            textwrap.dedent(
+                f"""\
+                #### Prediction stats  
+                Model used: **{d['model_name']}**  
+                Percentage of dead trees detected: **{(float(d['fraction'])*100):.2f}%** 
+                Inference duration: **{float(d['elapsed']):.1f}sec**  
+                """  # noqa
+            )
+        )
+    else:
+        # handle case with no image
+        st.write("Insert an image!")

--- a/deadtrees/network/segmodel.py
+++ b/deadtrees/network/segmodel.py
@@ -4,7 +4,6 @@ import logging
 
 import pytorch_lightning as pl
 import torch
-import wandb
 from deadtrees.loss.tversky.binary import BinaryTverskyLossV2
 from deadtrees.visualization.helper import show
 from omegaconf import DictConfig
@@ -123,6 +122,8 @@ class SemSegment(UNet, pl.LightningModule):  # type: ignore
             )
             for logger in self.logger:
                 if isinstance(logger, pl.loggers.wandb.WandbLogger):
+                    import wandb
+
                     logger.experiment.log(
                         {
                             "sample": wandb.Image(

--- a/dockerfiles/Dockerfile.backend
+++ b/dockerfiles/Dockerfile.backend
@@ -1,0 +1,21 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8-slim
+
+# only for albumentations, remove when they cleanup their dependencies  
+# https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies
+RUN apt-get update && \
+    apt-get install -y libgl1-mesa-dev libglib2.0-0 libsm6 libxrender1 libxext6
+
+RUN mkdir /backend
+
+COPY requirements-backend.txt /backend/requirements.txt
+
+WORKDIR /backend
+
+COPY . /backend
+
+RUN pip install -r requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
+
+
+EXPOSE 8000
+
+CMD ["uvicorn", "deadtrees.deployment.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/dockerfiles/Dockerfile.frontend
+++ b/dockerfiles/Dockerfile.frontend
@@ -1,0 +1,15 @@
+FROM python:3.8-slim
+
+RUN mkdir /frontend
+
+COPY requirements-frontend.txt /frontend/requirements.txt
+
+WORKDIR /frontend
+
+RUN pip install -r requirements.txt
+
+COPY . /frontend
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "deadtrees/deployment/ui.py"]


### PR DESCRIPTION
# A new inference app

This PR add a FastAPI backend that, given a source rgb image, returns a segmentation mask and some segmentation statistics.  
In addition, a sample Streamlit frontend app is provided for easy experimentation.

The backend is listening at port 8000, the fastapi app is started at port 8502. Both apps can be build and started using `docker-compose`.

## Build, start
```
docker-compose build
docker-compose up
```

Caveats:  
- currently the model is hardcoded to `bestmodel.ckpt` that is expected in the root dir (you currently need to put it there manually)
- only subtile images (512px) are currently processed

Next steps:  
- implement a subtitling function to split and merge large 8192px tiles into a batch of subtiles  
- make the model selectable in the frontend or via a REST call  
- load the model from a public S3 location  


This closes #11 (but lacks the batch/ tiling aspect)