### PR TITLE
Add (inference) setup for 2017 data

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -3,3 +3,4 @@
 /dataset
 /processed.images.2019
 /processed.masks.2019
+/processed.images.2017

--- a/data/raw/.gitignore
+++ b/data/raw/.gitignore
@@ -4,3 +4,4 @@
 /dead_treed_proj.shx
 /ortho_2019_ESPG3044.tif
 /shapefiles
+/ortho_2017_ESPG3044.tif

--- a/data/raw/ortho_2017_ESPG3044.tif.dvc
+++ b/data/raw/ortho_2017_ESPG3044.tif.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: a3dbc3a39bd6bb1c932ee887af198901
+  size: 381359748231
+  path: ortho_2017_ESPG3044.tif
+  isexec: true

--- a/deadtrees/deployment/tiler.py
+++ b/deadtrees/deployment/tiler.py
@@ -1,7 +1,10 @@
+# flake8: noqa: E402
 import argparse
 import warnings
 from pathlib import Path
 from typing import Optional, Union
+
+warnings.filterwarnings("ignore", category=UserWarning)
 
 import numpy as np
 import rioxarray
@@ -9,8 +12,6 @@ import torch
 from deadtrees.data.deadtreedata import val_transform
 from deadtrees.deployment.inference import ONNXInference, PyTorchInference
 from tqdm import tqdm
-
-warnings.filterwarnings("ignore", category=UserWarning)
 
 
 def is_tilable(infile: Union[str, Path]):
@@ -74,6 +75,16 @@ def unmake_blocks_vectorized(x: np.ndarray, d: int, m: int, n: int) -> np.ndarra
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("infile", type=Path)
+
+    parser.add_argument(
+        "-m",
+        "--model",
+        dest="model",
+        type=Path,
+        default=Path("checkpoints/bestmodel.ckpt"),
+        help="model artefact",
+    )
+
     parser.add_argument(
         "-o",
         dest="outpath",
@@ -101,7 +112,7 @@ def main():
             return False if np.isin(t, [0, 255]).all() else True
 
     # inference = ONNXInference("checkpoints/bestmodel.onnx")
-    inference = PyTorchInference("checkpoints/bestmodel.ckpt")
+    inference = PyTorchInference(args.model)
 
     #
     # model.to(device)

--- a/dvc.lock
+++ b/dvc.lock
@@ -84,3 +84,18 @@ stages:
       md5: f0bb5fb08c815bf826684b7d542f355d.dir
       size: 308807680
       nfiles: 11
+  createtiles@2017:
+    cmd: mkdir -p data/processed.images.2017; gdal_retile.py  -csv locations.csv  -v
+      -ps 8192 8192 -co "TILED=YES" -co "COMPRESS=LZW"  -targetDir data/processed.images.2017  data/raw/ortho_2017_ESPG3044.tif
+    deps:
+    - path: data/raw/ortho_2017_ESPG3044.tif
+      md5: a3dbc3a39bd6bb1c932ee887af198901
+      size: 381359748231
+    params:
+      params.yaml:
+        source_dim: 8192
+    outs:
+    - path: data/processed.images.2017
+      md5: 78c52e327b8dcd7dfbb5d43790326eb3.dir
+      size: 143381387397
+      nfiles: 1925

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -4,11 +4,11 @@
 stages:
   createtiles:
     foreach:
-    #  - 2017
+      - 2017
       - 2019
     do:
       cmd: >-
-        mkdir data/processed;
+        mkdir -p data/processed.images.${item};
         gdal_retile.py 
         -csv locations.csv 
         -v -ps ${source_dim} ${source_dim}

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -72,3 +72,26 @@ stages:
     - data/dataset/train_balanced_short
 
   # train:
+
+  # inference
+  inference:
+    foreach:
+      - 2017
+      - 2019
+    do:
+      cmd: >-
+        mkdir -p data/predicted.${item};
+        mkdir -p data/predicted.${item}_preview;
+        stdbuf -i0 -o0 -e0 python deadtrees/deployment/tiler.py --all -o data/predicted.${item} data/processed.images.${item};
+        gdal_merge.py 
+        -co 'COMPRESS=LZW' 
+        -co 'TILED=YES' 
+        -o data/predicted_mosaic_${item}.tif 
+        data/predicted.${item}/ortho_${item}_ESPG3044_*
+      deps:
+      - data/processed.images.${item}
+      outs:
+      - data/predicted.${item}
+      - data/predicted.${item}_preview
+      - data/predicted_mosaic_${item}.tif
+   

--- a/merge_prediction_tiles.sh
+++ b/merge_prediction_tiles.sh
@@ -1,2 +1,0 @@
-gdal_merge.py -co 'COMPRESS=LZW' -co 'TILED=YES' -o test_mosaic2.tif data/predicted.2019/ortho_2019_ESPG3044_*
-

--- a/process_all_gpu.sh
+++ b/process_all_gpu.sh
@@ -1,6 +1,0 @@
-for f in data/processed.images.2019/ortho_2019*
-do
-
-	stdbuf -i0 -o0 -e0 python deadtrees/deployment/tiler.py -o data/predicted.2019 $f
-done
-


### PR DESCRIPTION
With this PR year 2017 data is added. Also, an inference stage is now added to dvc.yaml. The manual steps required to infer on the individual images and successive merge into a mosaic tif are also integrated into this inference stage.