### PR TITLE
Add more model architectures

### DIFF
--- a/conf/datamodule/deadtrees.yaml
+++ b/conf/datamodule/deadtrees.yaml
@@ -3,14 +3,14 @@ datamodule:
   _target_: deadtrees.data.deadtreedata.DeadtreesDataModule
   pattern: "train-balanced-short-000*.tar"
   train_dataloader_conf:
-    batch_size: 8
-    num_workers: 4
+    batch_size: 4
+    num_workers: 2
   val_dataloader_conf:
-    batch_size: 8
-    num_workers: 4
+    batch_size: 4
+    num_workers: 2
   test_dataloader_conf:
-    batch_size: 8
-    num_workers: 4
+    batch_size: 4
+    num_workers: 2
 
 model:
   network_conf:

--- a/deadtrees/network/extra/__init__.py
+++ b/deadtrees/network/extra/__init__.py
@@ -1,0 +1,3 @@
+# models copied from https://github.com/jlcsilva/segmentation_models.pytorch
+# remove once PR is merged into the original repo: https://github.com/qubvel/segmentation_models.pytorch/pull/425
+# date: 2021-08-09

--- a/deadtrees/network/extra/__init__.py
+++ b/deadtrees/network/extra/__init__.py
@@ -1,3 +1,7 @@
 # models copied from https://github.com/jlcsilva/segmentation_models.pytorch
 # remove once PR is merged into the original repo: https://github.com/qubvel/segmentation_models.pytorch/pull/425
 # date: 2021-08-09
+
+from .efficientunetplusplus import EfficientUnetPlusPlus
+from .resunet import ResUnet
+from .resunetplusplus import ResUnetPlusPlus

--- a/deadtrees/network/extra/efficientunetplusplus/__init__.py
+++ b/deadtrees/network/extra/efficientunetplusplus/__init__.py
@@ -1,0 +1,1 @@
+from .model import EfficientUnetPlusPlus

--- a/deadtrees/network/extra/efficientunetplusplus/decoder.py
+++ b/deadtrees/network/extra/efficientunetplusplus/decoder.py
@@ -1,0 +1,184 @@
+from segmentation_models_pytorch.base import modules as md
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.functional import norm
+
+
+class InvertedResidual(nn.Module):
+    """
+    Inverted bottleneck residual block with an scSE block embedded into the residual layer, after the
+    depthwise convolution. By default, uses batch normalization and Hardswish activation.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size=3,
+        stride=1,
+        expansion_ratio=1,
+        squeeze_ratio=1,
+        activation=nn.Hardswish(True),
+        normalization=nn.BatchNorm2d,
+    ):
+        super().__init__()
+        self.same_shape = in_channels == out_channels
+        self.mid_channels = expansion_ratio * in_channels
+        self.block = nn.Sequential(
+            md.PointWiseConv2d(in_channels, self.mid_channels),
+            normalization(self.mid_channels),
+            activation,
+            md.DepthWiseConv2d(
+                self.mid_channels, kernel_size=kernel_size, stride=stride
+            ),
+            normalization(self.mid_channels),
+            activation,
+            # md.sSEModule(self.mid_channels),
+            md.SCSEModule(self.mid_channels, reduction=squeeze_ratio),
+            # md.SEModule(self.mid_channels, reduction = squeeze_ratio),
+            md.PointWiseConv2d(self.mid_channels, out_channels),
+            normalization(out_channels),
+        )
+
+        if not self.same_shape:
+            # 1x1 convolution used to match the number of channels in the skip feature maps with that
+            # of the residual feature maps
+            self.skip_conv = nn.Sequential(
+                nn.Conv2d(
+                    in_channels=in_channels, out_channels=out_channels, kernel_size=1
+                ),
+                normalization(out_channels),
+            )
+
+    def forward(self, x):
+        residual = self.block(x)
+
+        if not self.same_shape:
+            x = self.skip_conv(x)
+        return x + residual
+
+
+class DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        skip_channels,
+        out_channels,
+        squeeze_ratio=1,
+        expansion_ratio=1,
+    ):
+        super().__init__()
+
+        # Inverted Residual block convolutions
+        self.conv1 = InvertedResidual(
+            in_channels=in_channels + skip_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=1,
+            expansion_ratio=expansion_ratio,
+            squeeze_ratio=squeeze_ratio,
+        )
+        self.conv2 = InvertedResidual(
+            in_channels=out_channels,
+            out_channels=out_channels,
+            kernel_size=3,
+            stride=1,
+            expansion_ratio=expansion_ratio,
+            squeeze_ratio=squeeze_ratio,
+        )
+
+    def forward(self, x, skip=None):
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+
+        if skip is not None:
+            x = torch.cat([x, skip], dim=1)
+        x = self.conv1(x)
+        x = self.conv2(x)
+        return x
+
+
+class EfficientUnetPlusPlusDecoder(nn.Module):
+    def __init__(
+        self,
+        encoder_channels,
+        decoder_channels,
+        n_blocks=5,
+        squeeze_ratio=1,
+        expansion_ratio=1,
+    ):
+        super().__init__()
+        if n_blocks != len(decoder_channels):
+            raise ValueError(
+                "Model depth is {}, but you provide `decoder_channels` for {} blocks.".format(
+                    n_blocks, len(decoder_channels)
+                )
+            )
+
+        encoder_channels = encoder_channels[
+            1:
+        ]  # remove first skip with same spatial resolution
+        encoder_channels = encoder_channels[
+            ::-1
+        ]  # reverse channels to start from head of encoder
+        # computing blocks input and output channels
+        head_channels = encoder_channels[0]
+        self.in_channels = [head_channels] + list(decoder_channels[:-1])
+        self.skip_channels = list(encoder_channels[1:]) + [0]
+        self.out_channels = decoder_channels
+
+        # combine decoder keyword arguments
+        kwargs = dict(squeeze_ratio=squeeze_ratio, expansion_ratio=expansion_ratio)
+
+        blocks = {}
+        for layer_idx in range(len(self.in_channels) - 1):
+            for depth_idx in range(layer_idx + 1):
+                if depth_idx == 0:
+                    in_ch = self.in_channels[layer_idx]
+                    skip_ch = self.skip_channels[layer_idx] * (layer_idx + 1)
+                    out_ch = self.out_channels[layer_idx]
+                else:
+                    out_ch = self.skip_channels[layer_idx]
+                    skip_ch = self.skip_channels[layer_idx] * (
+                        layer_idx + 1 - depth_idx
+                    )
+                    in_ch = self.skip_channels[layer_idx - 1]
+                blocks[f"x_{depth_idx}_{layer_idx}"] = DecoderBlock(
+                    in_ch, skip_ch, out_ch, **kwargs
+                )
+        blocks[f"x_{0}_{len(self.in_channels)-1}"] = DecoderBlock(
+            self.in_channels[-1], 0, self.out_channels[-1], **kwargs
+        )
+        self.blocks = nn.ModuleDict(blocks)
+        self.depth = len(self.in_channels) - 1
+
+    def forward(self, *features):
+
+        features = features[1:]  # remove first skip with same spatial resolution
+        features = features[::-1]  # reverse channels to start from head of encoder
+        # start building dense connections
+        dense_x = {}
+        for layer_idx in range(len(self.in_channels) - 1):
+            for depth_idx in range(self.depth - layer_idx):
+                if layer_idx == 0:
+                    output = self.blocks[f"x_{depth_idx}_{depth_idx}"](
+                        features[depth_idx], features[depth_idx + 1]
+                    )
+                    dense_x[f"x_{depth_idx}_{depth_idx}"] = output
+                else:
+                    dense_l_i = depth_idx + layer_idx
+                    cat_features = [
+                        dense_x[f"x_{idx}_{dense_l_i}"]
+                        for idx in range(depth_idx + 1, dense_l_i + 1)
+                    ]
+                    cat_features = torch.cat(
+                        cat_features + [features[dense_l_i + 1]], dim=1
+                    )
+                    dense_x[f"x_{depth_idx}_{dense_l_i}"] = self.blocks[
+                        f"x_{depth_idx}_{dense_l_i}"
+                    ](dense_x[f"x_{depth_idx}_{dense_l_i-1}"], cat_features)
+        dense_x[f"x_{0}_{self.depth}"] = self.blocks[f"x_{0}_{self.depth}"](
+            dense_x[f"x_{0}_{self.depth-1}"]
+        )
+        return dense_x[f"x_{0}_{self.depth}"]

--- a/deadtrees/network/extra/efficientunetplusplus/decoder.py
+++ b/deadtrees/network/extra/efficientunetplusplus/decoder.py
@@ -1,8 +1,8 @@
-from segmentation_models_pytorch.base import modules as md
-
+# from segmentation_models_pytorch.base import modules as md
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from deadtrees.network.extra import modules as md
 from torch.functional import norm
 
 

--- a/deadtrees/network/extra/efficientunetplusplus/model.py
+++ b/deadtrees/network/extra/efficientunetplusplus/model.py
@@ -1,0 +1,133 @@
+from typing import List, Optional, Union
+
+from segmentation_models_pytorch.base import (
+    ClassificationHead,
+    SegmentationHead,
+    SegmentationModel,
+)
+from segmentation_models_pytorch.encoders import get_encoder
+
+import torch
+from torchvision import transforms
+
+from .decoder import EfficientUnetPlusPlusDecoder
+
+
+class EfficientUnetPlusPlus(SegmentationModel):
+    """The EfficientUNet++ is a fully convolutional neural network for ordinary and medical image semantic segmentation.
+    Consists of an *encoder* and a *decoder*, connected by *skip connections*. The encoder extracts features of
+    different spatial resolutions, which are fed to the decoder through skip connections. The decoder combines its
+    own feature maps with the ones from skip connections to produce accurate segmentations masks.  The EfficientUNet++
+    decoder architecture is based on the UNet++, a model composed of nested U-Net-like decoder sub-networks. To
+    increase performance and computational efficiency, the EfficientUNet++ replaces the UNet++'s blocks with
+    inverted residual blocks with depthwise convolutions and embedded spatial and channel attention mechanisms.
+    Synergizes well with EfficientNet encoders. Due to their efficient visual representations (i.e., using few channels
+    to represent extracted features), EfficientNet encoders require few computation from the decoder.
+
+    Args:
+        encoder_name: Name of the classification model that will be used as an encoder (a.k.a backbone) to extract features
+        encoder_depth: Number of stages of the encoder, in range [3 ,5]. Each stage generate features two times smaller,
+            in spatial dimensions, than the previous one (e.g., for depth=0 features will haves shapes [(N, C, H, W)]),
+            for depth 1 features will have shapes [(N, C, H, W), (N, C, H // 2, W // 2)] and so on).
+            Default is 5
+        encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and
+            other pretrained weights (see table with available weights for each encoder_name)
+        decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in the decoder.
+            Length of the list should be the same as **encoder_depth**
+        in_channels: The number of input channels of the model, default is 3 (RGB images)
+        classes: The number of classes of the output mask. Can be thought of as the number of channels of the mask
+        activation: An activation function to apply after the final convolution layer.
+            Available options are **"sigmoid"**, **"softmax"**, **"logsoftmax"**, **"tanh"**, **"identity"**, **callable** and **None**.
+            Default is **None**
+        aux_params: Dictionary with parameters of the auxiliary output (classification head). Auxiliary output is built
+            on top of encoder if **aux_params** is not **None** (default). Supported params:
+                - classes (int): A number of classes
+                - pooling (str): One of "max", "avg". Default is "avg"
+                - dropout (float): Dropout factor in [0, 1)
+                - activation (str): An activation function to apply "sigmoid"/"softmax" (could be **None** to return logits)
+    Returns:
+        ``torch.nn.Module``: **EfficientUnet++**
+
+    Reference:
+        https://arxiv.org/abs/2106.11447
+    """
+
+    def __init__(
+        self,
+        encoder_name: str = "timm-efficientnet-b5",
+        encoder_depth: int = 5,
+        encoder_weights: Optional[str] = "imagenet",
+        decoder_channels: List[int] = (256, 128, 64, 32, 16),
+        squeeze_ratio: int = 1,
+        expansion_ratio: int = 1,
+        in_channels: int = 3,
+        classes: int = 1,
+        activation: Optional[Union[str, callable]] = None,
+        aux_params: Optional[dict] = None,
+    ):
+        super().__init__()
+        self.classes = classes
+        self.encoder = get_encoder(
+            encoder_name,
+            in_channels=in_channels,
+            depth=encoder_depth,
+            weights=encoder_weights,
+        )
+
+        self.decoder = EfficientUnetPlusPlusDecoder(
+            encoder_channels=self.encoder.out_channels,
+            decoder_channels=decoder_channels,
+            n_blocks=encoder_depth,
+            squeeze_ratio=squeeze_ratio,
+            expansion_ratio=expansion_ratio,
+        )
+
+        self.segmentation_head = SegmentationHead(
+            in_channels=decoder_channels[-1],
+            out_channels=classes,
+            activation=activation,
+            kernel_size=3,
+        )
+
+        if aux_params is not None:
+            self.classification_head = ClassificationHead(
+                in_channels=self.encoder.out_channels[-1], **aux_params
+            )
+        else:
+            self.classification_head = None
+
+        self.name = "EfficientUNet++-{}".format(encoder_name)
+        self.initialize()
+
+    def predict(self, x):
+        """Inference method. Switch model to `eval` mode, call `.forward(x)` with `torch.no_grad()`
+
+        Args:
+            x: 4D torch tensor with shape (batch_size, channels, height, width)
+
+        Return:
+            prediction: 4D torch tensor with shape (batch_size, classes, height, width)
+
+        """
+        if self.training:
+            self.eval()
+
+        with torch.no_grad():
+            output = self.forward(x)
+
+        if self.classes > 1:
+            probs = torch.softmax(output, dim=1)
+        else:
+            probs = torch.sigmoid(output)
+
+        probs = probs.squeeze(0)
+        tf = transforms.Compose(
+            [
+                transforms.ToPILImage(),
+                transforms.Resize(x.size[1]),
+                transforms.ToTensor(),
+            ]
+        )
+        full_mask = tf(probs.cpu())
+
+        return full_mask

--- a/deadtrees/network/extra/resunet/__init__.py
+++ b/deadtrees/network/extra/resunet/__init__.py
@@ -1,0 +1,1 @@
+from .model import ResUnet

--- a/deadtrees/network/extra/resunet/decoder.py
+++ b/deadtrees/network/extra/resunet/decoder.py
@@ -1,8 +1,8 @@
-from segmentation_models_pytorch.base import modules as md
-
+# from segmentation_models_pytorch.base import modules as md
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from deadtrees.network.extra import modules as md
 
 
 class DecoderBlock(nn.Module):

--- a/deadtrees/network/extra/resunet/decoder.py
+++ b/deadtrees/network/extra/resunet/decoder.py
@@ -1,0 +1,134 @@
+from segmentation_models_pytorch.base import modules as md
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        skip_channels,
+        out_channels,
+        use_batchnorm=True,
+        attention_type=None,
+    ):
+        super().__init__()
+        self.conv1 = md.PreActivatedConv2dReLU(
+            in_channels + skip_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        self.attention1 = md.Attention(
+            attention_type, in_channels=in_channels + skip_channels
+        )
+        self.conv2 = md.PreActivatedConv2dReLU(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        self.attention2 = md.Attention(attention_type, in_channels=out_channels)
+        self.identity_conv = nn.Conv2d(
+            in_channels + skip_channels, out_channels, kernel_size=1
+        )
+
+    def forward(self, x, skip=None):
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if skip is not None:
+            x = torch.cat([x, skip], dim=1)
+            identity = x
+            x = self.attention1(x)
+        else:
+            identity = x
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.attention2(x)
+        identity = self.identity_conv(identity)
+        return x + identity
+
+
+class CenterBlock(nn.Sequential):
+    def __init__(self, in_channels, out_channels, use_batchnorm=True):
+        conv1 = md.PreActivatedConv2dReLU(
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        conv2 = md.PreActivatedConv2dReLU(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        super().__init__(conv1, conv2)
+
+
+class ResUnetDecoder(nn.Module):
+    def __init__(
+        self,
+        encoder_channels,
+        decoder_channels,
+        n_blocks=5,
+        use_batchnorm=True,
+        attention_type=None,
+        center=False,
+    ):
+        super().__init__()
+
+        if n_blocks != len(decoder_channels):
+            raise ValueError(
+                "Model depth is {}, but you provide `decoder_channels` for {} blocks.".format(
+                    n_blocks, len(decoder_channels)
+                )
+            )
+
+        encoder_channels = encoder_channels[
+            1:
+        ]  # remove first skip with same spatial resolution
+        encoder_channels = encoder_channels[
+            ::-1
+        ]  # reverse channels to start from head of encoder
+
+        # computing blocks input and output channels
+        head_channels = encoder_channels[0]
+        in_channels = [head_channels] + list(decoder_channels[:-1])
+        skip_channels = list(encoder_channels[1:]) + [0]
+        out_channels = decoder_channels
+
+        if center:
+            self.center = CenterBlock(
+                head_channels, head_channels, use_batchnorm=use_batchnorm
+            )
+        else:
+            self.center = nn.Identity()
+
+        # combine decoder keyword arguments
+        kwargs = dict(use_batchnorm=use_batchnorm, attention_type=attention_type)
+        blocks = [
+            DecoderBlock(in_ch, skip_ch, out_ch, **kwargs)
+            for in_ch, skip_ch, out_ch in zip(in_channels, skip_channels, out_channels)
+        ]
+        self.blocks = nn.ModuleList(blocks)
+
+    def forward(self, *features):
+
+        features = features[1:]  # remove first skip with same spatial resolution
+        features = features[::-1]  # reverse channels to start from head of encoder
+
+        head = features[0]
+        skips = features[1:]
+
+        x = self.center(head)
+        for i, decoder_block in enumerate(self.blocks):
+            skip = skips[i] if i < len(skips) else None
+            x = decoder_block(x, skip)
+
+        return x

--- a/deadtrees/network/extra/resunet/model.py
+++ b/deadtrees/network/extra/resunet/model.py
@@ -1,0 +1,103 @@
+from typing import List, Optional, Union
+
+from segmentation_models_pytorch.base import (
+    ClassificationHead,
+    SegmentationHead,
+    SegmentationModel,
+)
+from segmentation_models_pytorch.encoders import get_encoder
+
+from .decoder import ResUnetDecoder
+
+
+class ResUnet(SegmentationModel):
+    """ResUnet_ is a fully convolution neural network for image semantic segmentation. Consist of *encoder*
+    and *decoder* parts connected with *skip connections*. Encoder extract features of different spatial
+    resolution (skip connections) which are used by decoder to define accurate segmentation mask. Use *concatenation*
+    for fusing decoder blocks with skip connections. Use residual connections inside each decoder block.
+
+    Args:
+        encoder_name: Name of the classification model that will be used as an encoder (a.k.a backbone) to extract features
+        encoder_depth: Number of stages of the encoder, in range [3 ,5]. Each stage generate features two times smaller,
+            in spatial dimensions, than the previous one (e.g., for depth=0 features will haves shapes [(N, C, H, W)]),
+            for depth 1 features will have shapes [(N, C, H, W), (N, C, H // 2, W // 2)] and so on).
+            Default is 5
+        encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and
+            other pretrained weights (see table with available weights for each encoder_name)
+        decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in the decoder.
+            Length of the list should be the same as **encoder_depth**
+        decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers
+            is used. If **"inplace"** InplaceABN will be used, allows to decrease memory consumption.
+            Available options are **True, False, "inplace"**
+        decoder_attention_type: Attention module used in decoder of the model. Available options are **None**, **se** and **scse**.
+            SE paper - https://arxiv.org/abs/1709.01507
+            SCSE paper - https://arxiv.org/abs/1808.08127
+        in_channels: The number of input channels of the model, default is 3 (RGB images)
+        classes: The number of classes of the output mask. Can be thought of as the number of channels of the mask
+        activation: An activation function to apply after the final convolution layer.
+            Available options are **"sigmoid"**, **"softmax"**, **"logsoftmax"**, **"tanh"**, **"identity"**, **callable** and **None**.
+            Default is **None**
+        aux_params: Dictionary with parameters of the auxiliary output (classification head). Auxiliary output is build
+            on top of encoder if **aux_params** is not **None** (default). Supported params:
+                - classes (int): A number of classes
+                - pooling (str): One of "max", "avg". Default is "avg"
+                - dropout (float): Dropout factor in [0, 1)
+                - activation (str): An activation function to apply "sigmoid"/"softmax" (could be **None** to return logits)
+
+    Returns:
+        ``torch.nn.Module``: ResUnet
+
+    .. _ResUnet:
+        https://arxiv.org/abs/1711.10684
+
+    Reference:
+        https://arxiv.org/abs/1711.10684
+    """
+
+    def __init__(
+        self,
+        encoder_name: str = "resnet34",
+        encoder_depth: int = 5,
+        encoder_weights: Optional[str] = "imagenet",
+        decoder_use_batchnorm: bool = True,
+        decoder_channels: List[int] = (256, 128, 64, 32, 16),
+        decoder_attention_type: Optional[str] = None,
+        in_channels: int = 3,
+        classes: int = 1,
+        activation: Optional[Union[str, callable]] = None,
+        aux_params: Optional[dict] = None,
+    ):
+        super().__init__()
+
+        self.encoder = get_encoder(
+            encoder_name,
+            in_channels=in_channels,
+            depth=encoder_depth,
+            weights=encoder_weights,
+        )
+
+        self.decoder = ResUnetDecoder(
+            encoder_channels=self.encoder.out_channels,
+            decoder_channels=decoder_channels,
+            n_blocks=encoder_depth,
+            use_batchnorm=decoder_use_batchnorm,
+            center=True if encoder_name.startswith("vgg") else False,
+            attention_type=decoder_attention_type,
+        )
+
+        self.segmentation_head = SegmentationHead(
+            in_channels=decoder_channels[-1],
+            out_channels=classes,
+            activation=activation,
+            kernel_size=1,
+        )
+
+        if aux_params is not None:
+            self.classification_head = ClassificationHead(
+                in_channels=self.encoder.out_channels[-1], **aux_params
+            )
+        else:
+            self.classification_head = None
+
+        self.name = "resunet-{}".format(encoder_name)
+        self.initialize()

--- a/deadtrees/network/extra/resunetplusplus/__init__.py
+++ b/deadtrees/network/extra/resunetplusplus/__init__.py
@@ -1,0 +1,1 @@
+from .model import ResUnetPlusPlus

--- a/deadtrees/network/extra/resunetplusplus/decoder.py
+++ b/deadtrees/network/extra/resunetplusplus/decoder.py
@@ -1,0 +1,225 @@
+from segmentation_models_pytorch.base import modules as md
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class ASPP(nn.Module):
+    """ASPP described in https://arxiv.org/pdf/1706.05587.pdf but without the concatenation of 1x1, original feature maps and global average pooling"""
+
+    def __init__(self, in_channels, out_channels, rate=[6, 12, 18]):
+        super(ASPP, self).__init__()
+
+        # Dilation rates of 6, 12 and 18 for the Atrous Spatial Pyramid Pooling blocks
+        self.aspp_block1 = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                padding=rate[0],
+                dilation=rate[0],
+            ),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm2d(out_channels),
+        )
+        self.aspp_block2 = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                padding=rate[1],
+                dilation=rate[1],
+            ),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm2d(out_channels),
+        )
+        self.aspp_block3 = nn.Sequential(
+            nn.Conv2d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                padding=rate[2],
+                dilation=rate[2],
+            ),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm2d(out_channels),
+        )
+        self.aspp_block4 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.BatchNorm2d(out_channels),
+        )
+
+        self.output = nn.Conv2d(
+            (len(rate) + 1) * out_channels, out_channels, kernel_size=1
+        )
+        self._init_weights()
+
+    def forward(self, x):
+
+        x1 = self.aspp_block1(x)
+        x2 = self.aspp_block2(x)
+        x3 = self.aspp_block3(x)
+        x4 = self.aspp_block4(x)
+        out = torch.cat([x1, x2, x3, x4], dim=1)
+
+        return self.output(out)
+
+    def _init_weights(self):
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight)
+            elif isinstance(m, nn.BatchNorm2d):
+                m.weight.data.fill_(1)
+                m.bias.data.zero_()
+
+
+class AttentionBlock(nn.Module):
+    def __init__(self, skip_channels, in_channels, out_channels):
+        super(AttentionBlock, self).__init__()
+
+        if skip_channels != 0:
+            self.encoder_conv = nn.Sequential(
+                nn.BatchNorm2d(skip_channels),
+                nn.ReLU(),
+                nn.Conv2d(skip_channels, out_channels, kernel_size=3, padding=1),
+                nn.MaxPool2d(
+                    kernel_size=2, stride=2
+                ),  # Attention is used before upsampling, so the encoder feature maps need to be downsampled
+            )
+
+        self.decoder_conv = nn.Sequential(
+            nn.BatchNorm2d(in_channels),
+            nn.ReLU(),
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+        )
+
+        self.attn_conv = nn.Sequential(
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(),
+            nn.Conv2d(
+                in_channels=out_channels, out_channels=in_channels, kernel_size=1
+            ),
+            nn.AdaptiveAvgPool2d(1),
+        )
+
+    def forward(self, x, skip=None):
+        # Apply BN, ReLU and 3x3 conv to incoming feature maps to obtain the desired number of feature maps and be able to sum them
+        if skip is not None:
+            out = self.encoder_conv(skip) + self.decoder_conv(x)
+        else:
+            out = self.decoder_conv(x)
+        out = self.attn_conv(out)  # Compute a BCHW attention mask
+        return out * x  # Apply the attention mask to the input coming from the decoder
+
+
+class DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        skip_channels,
+        out_channels,
+        use_batchnorm=True,
+        attention_type=None,
+    ):
+        super().__init__()
+        self.attention0 = AttentionBlock(skip_channels, in_channels, in_channels)
+        self.conv1 = md.PreActivatedConv2dReLU(
+            in_channels + skip_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        self.attention1 = md.Attention(
+            attention_type, in_channels=in_channels + skip_channels
+        )
+        self.conv2 = md.PreActivatedConv2dReLU(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            padding=1,
+            use_batchnorm=use_batchnorm,
+        )
+        self.attention2 = md.Attention(attention_type, in_channels=out_channels)
+        self.identity_conv = nn.Conv2d(
+            in_channels + skip_channels, out_channels, kernel_size=1
+        )
+
+    def forward(self, x, skip=None):
+        x = self.attention0(x, skip)
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if skip is not None:
+            x = torch.cat([x, skip], dim=1)
+            identity = x
+            x = self.attention1(x)
+        else:
+            identity = x
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.attention2(x)
+        identity = self.identity_conv(identity)
+        return x + identity
+
+
+class ResUnetPlusPlusDecoder(nn.Module):
+    def __init__(
+        self,
+        encoder_channels,
+        decoder_channels,
+        n_blocks=5,
+        use_batchnorm=True,
+        attention_type=None,
+    ):
+        super().__init__()
+
+        if n_blocks != len(decoder_channels):
+            raise ValueError(
+                "Model depth is {}, but you provide `decoder_channels` for {} blocks.".format(
+                    n_blocks, len(decoder_channels)
+                )
+            )
+
+        encoder_channels = encoder_channels[
+            1:
+        ]  # remove first skip with same spatial resolution
+        encoder_channels = encoder_channels[
+            ::-1
+        ]  # reverse channels to start from head of encoder
+
+        # computing blocks input and output channels
+        head_channels = encoder_channels[0]
+        in_channels = [2 * head_channels] + [i * 2 for i in decoder_channels[:-1]]
+        skip_channels = list(encoder_channels[1:]) + [0]
+        out_channels = [i * 2 for i in decoder_channels]  # decoder_channels
+
+        self.center = ASPP(head_channels, in_channels[0])
+
+        # combine decoder keyword arguments
+        kwargs = dict(use_batchnorm=use_batchnorm, attention_type=attention_type)
+        blocks = [
+            DecoderBlock(in_ch, skip_ch, out_ch, **kwargs)
+            for in_ch, skip_ch, out_ch in zip(in_channels, skip_channels, out_channels)
+        ]
+        self.blocks = nn.ModuleList(blocks)
+        self.final_aspp = ASPP(out_channels[-1], out_channels[-1] // 2)
+
+    def forward(self, *features):
+
+        features = features[1:]  # remove first skip with same spatial resolution
+        features = features[::-1]  # reverse channels to start from head of encoder
+
+        head = features[0]
+        skips = features[1:]
+
+        x = self.center(head)
+        for i, decoder_block in enumerate(self.blocks):
+            skip = skips[i] if i < len(skips) else None
+            x = decoder_block(x, skip)
+        x = self.final_aspp(x)
+
+        return x

--- a/deadtrees/network/extra/resunetplusplus/decoder.py
+++ b/deadtrees/network/extra/resunetplusplus/decoder.py
@@ -1,8 +1,8 @@
-from segmentation_models_pytorch.base import modules as md
-
+# from segmentation_models_pytorch.base import modules as md
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from deadtrees.network.extra import modules as md
 
 
 class ASPP(nn.Module):

--- a/deadtrees/network/extra/resunetplusplus/model.py
+++ b/deadtrees/network/extra/resunetplusplus/model.py
@@ -1,0 +1,104 @@
+from typing import List, Optional, Union
+
+from segmentation_models_pytorch.base import (
+    ClassificationHead,
+    SegmentationHead,
+    SegmentationModel,
+)
+from segmentation_models_pytorch.encoders import get_encoder
+
+from .decoder import ResUnetPlusPlusDecoder
+
+
+class ResUnetPlusPlus(SegmentationModel):
+    """ResUnet++ is a fully convolution neural network for image semantic segmentation. Consist of *encoder*
+    and *decoder* parts connected with *skip connections*. The encoder extracts features of different spatial
+    resolution (skip connections) which are used by decoder to define accurate segmentation mask.
+
+    Applies attention to the skip connection feature maps, based on themselves and the decoder feature maps.
+    The skip connection feature maps are then fused with the decoder feature maps through *concatenation*.
+    Uses an Atrous Spatial Pyramid Pooling (ASPP) bridge module and residual connections inside each decoder
+    blocks.
+
+    Args:
+        encoder_name: Name of the classification model that will be used as an encoder (a.k.a backbone) to extract features
+        encoder_depth: Number of stages of the encoder, in range [3 ,5]. Each stage generate features two times smaller,
+            in spatial dimensions, than the previous one (e.g., for depth=0 features will haves shapes [(N, C, H, W)]),
+            for depth 1 features will have shapes [(N, C, H, W), (N, C, H // 2, W // 2)] and so on).
+            Default is 5
+        encoder_weights: One of **None** (random initialization), **"imagenet"** (pre-training on ImageNet) and
+            other pretrained weights (see table with available weights for each encoder_name)
+        decoder_channels: List of integers which specify **in_channels** parameter for convolutions used in the decoder.
+            Length of the list should be the same as **encoder_depth**
+        decoder_use_batchnorm: If **True**, BatchNorm2d layer between Conv2D and Activation layers
+            is used. If **"inplace"** InplaceABN will be used, allows to decrease memory consumption.
+            Available options are **True, False, "inplace"**
+        decoder_attention_type: Attention module used in decoder of the model (in addition to the built-in attention used to
+            process skip connection feature maps). Available options are **None**, **se** and **scse**.
+            SE paper - https://arxiv.org/abs/1709.01507
+            SCSE paper - https://arxiv.org/abs/1808.08127
+        in_channels: The number of input channels of the model, default is 3 (RGB images)
+        classes: The number of classes of the output mask. Can be thought of as the number of channels of the mask
+        activation: An activation function to apply after the final convolution layer.
+            Available options are **"sigmoid"**, **"softmax"**, **"logsoftmax"**, **"tanh"**, **"identity"**, **callable** and **None**.
+            Default is **None**
+        aux_params: Dictionary with parameters of the auxiliary output (classification head). Auxiliary output is build
+            on top of encoder if **aux_params** is not **None** (default). Supported params:
+                - classes (int): A number of classes
+                - pooling (str): One of "max", "avg". Default is "avg"
+                - dropout (float): Dropout factor in [0, 1)
+                - activation (str): An activation function to apply "sigmoid"/"softmax" (could be **None** to return logits)
+
+    Returns:
+        ``torch.nn.Module``: ResUnetPlusPlus
+
+    Reference:
+        https://arxiv.org/abs/1911.07067
+    """
+
+    def __init__(
+        self,
+        encoder_name: str = "resnet34",
+        encoder_depth: int = 5,
+        encoder_weights: Optional[str] = "imagenet",
+        decoder_use_batchnorm: bool = True,
+        decoder_channels: List[int] = (256, 128, 64, 32, 16),
+        decoder_attention_type: Optional[str] = None,
+        in_channels: int = 3,
+        classes: int = 1,
+        activation: Optional[Union[str, callable]] = None,
+        aux_params: Optional[dict] = None,
+    ):
+        super().__init__()
+
+        self.encoder = get_encoder(
+            encoder_name,
+            in_channels=in_channels,
+            depth=encoder_depth,
+            weights=encoder_weights,
+        )
+
+        self.decoder = ResUnetPlusPlusDecoder(
+            encoder_channels=self.encoder.out_channels,
+            decoder_channels=decoder_channels,
+            n_blocks=encoder_depth,
+            use_batchnorm=decoder_use_batchnorm,
+            attention_type=decoder_attention_type,
+        )
+
+        self.segmentation_head = SegmentationHead(
+            in_channels=decoder_channels[-1],
+            out_channels=classes,
+            activation=activation,
+            kernel_size=1,
+        )
+
+        if aux_params is not None:
+            self.classification_head = ClassificationHead(
+                in_channels=self.encoder.out_channels[-1], **aux_params
+            )
+        else:
+            self.classification_head = None
+
+        self.name = "resunet++-{}".format(encoder_name)
+        self.initialize()

--- a/deadtrees/network/segmodel.py
+++ b/deadtrees/network/segmodel.py
@@ -8,6 +8,7 @@ import segmentation_models_pytorch as smp
 import pandas as pd
 import pytorch_lightning as pl
 import torch
+from deadtrees.network.extra import EfficientUnetPlusPlus, ResUnet, ResUnetPlusPlus
 from deadtrees.visualization.helper import show
 from omegaconf import DictConfig
 
@@ -27,9 +28,15 @@ class SemSegment(pl.LightningModule):  # type: ignore
             Model = smp.Unet
         elif architecture in ["unetplusplus", "unet++"]:
             Model = smp.UnetPlusPlus
+        elif architecture == "resunet":
+            Model = ResUnet
+        elif architecture in ["resunetplusplus", "resunet++"]:
+            Model = ResUnetPlusPlus
+        elif architecture in ["efficientunetplusplus", "efficientunet++"]:
+            Model = EfficientUnetPlusPlus
         else:
             raise NotImplementedError(
-                "Currently only Unet and UnetPlusPLus architectures are supported"
+                "Currently only Unet, ResUnet, Unet++, ResUnet++, and EfficientUnet++ architectures are supported"
             )
 
         del network_conf.architecture

--- a/sweep.yaml
+++ b/sweep.yaml
@@ -1,5 +1,5 @@
 program: scripts/train.py
-method: bayes
+method: grid #bayes
 command:
   - ${env}
   - ${interpreter}
@@ -9,22 +9,25 @@ metric:
   name: val/total_loss
   goal: minimize
 parameters:
-  train.learning_rate:
-    distribution: log_uniform
-    min: -11
-    max: -6
+  # train.learning_rate:
+  #   distribution: log_uniform
+  #   min: -11
+  #   max: -6
 
   model.network_conf.architecture:
     distribution: categorical
     values:
       - "unet"
-      - "unetplusplus"
+      - "unet++"
+      - "resunet"
+      - "resunet++"
+      - "efficientunet++"
   
   model.network_conf.encoder_name:
     distribution: categorical
     values:
       - "resnet34"
-      - "resnet50" 
-      - "efficientnet-b5"
-      - "efficientnet-b6"
+      #- "resnet50" 
+      #- "efficientnet-b5"
+      #- "efficientnet-b6"
       - "efficientnet-b7"


### PR DESCRIPTION
This PR adds more model architectures (resent, resunet++, efficientunet++) that are currently pending in a PR (https://github.com/qubvel/segmentation_models.pytorch/pull/425) and hopefully will be merged soon into the official segmentation_models.pytorch (https://github.com/qubvel/segmentation_models.pytorch) repository. Once this happens, the current code under the `extras` folder in this repo is obsolete and will be removed again.
