### PR TITLE
Add combo dataset (balanced+random) with 256 shard size 

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -14,7 +14,7 @@ trainer:
 
 defaults:
     - callbacks: default_callbacks
-    - datamodule: deadtrees_multi_datasets_singleclass_rgbn
+    - datamodule: deadtrees_combo_dataset_singleclass_rgbn
     - model: default
     - logger: wandb
 

--- a/conf/datamodule/deadtrees_combo_dataset_singleclass_rgbn.yaml
+++ b/conf/datamodule/deadtrees_combo_dataset_singleclass_rgbn.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+datamodule:
+  _target_: deadtrees.data.deadtreedata.DeadtreesDataModule
+  pattern: "train-combo-000*.tar"
+  train_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+  val_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+  test_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+
+model:
+  network_conf:
+    classes: 2
+    in_channels: 4

--- a/dvc.lock
+++ b/dvc.lock
@@ -67,9 +67,9 @@ stages:
       md5: 5d5e6ab2648bdb6b7846d4c8655a72a8
       size: 2539255
     - path: data/dataset/train
-      md5: 155ce2ddabeab3e619b59e016093ae30.dir
-      size: 6895349760
-      nfiles: 162
+      md5: 09daf34f435e8a47ce8879a6f7a9899e.dir
+      size: 10832783360
+      nfiles: 208
   createbalanced:
     cmd: python scripts/createbalanced.py  data/dataset/stats.csv data/dataset/train  data/dataset/train_balanced  data/dataset/train_balanced_short
       --format TIFF --tmp-dir ./tmp


### PR DESCRIPTION
… and make this the new default config.

This new default dataset works with a single data loader (faster) and basically is the balanced train dataset interleaved with random samples. Size is 2*len(balanced) aka 256 samples per shard. All shards of balanced and the new combo dataset are now excatly 128/ 256 samples long. 

Closes #56.  