### PR TITLE
Add forest masks and confusion matrix

### DIFF
--- a/checkpoints/bestmodel.ckpt.dvc
+++ b/checkpoints/bestmodel.ckpt.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: 0830f3f736486d7c9a3d5d59c64ef89d
+- md5: c59487c86e6f7bcb14a5c497a7f0089b
   size: 378716396
   path: bestmodel.ckpt

--- a/checkpoints/bestmodel.ckpt.dvc
+++ b/checkpoints/bestmodel.ckpt.dvc
@@ -1,4 +1,4 @@
 outs:
-- md5: c59487c86e6f7bcb14a5c497a7f0089b
-  size: 378716396
+- md5: 5c886ef2b930d86ad75001127751b0aa
+  size: 378718764
   path: bestmodel.ckpt

--- a/checkpoints/bestmodel.txt
+++ b/checkpoints/bestmodel.txt
@@ -1,2 +1,2 @@
-eunet++_eunet-b5 epoch:170 2021-01-09 01:23:29
+festive-peony-3193 epoch:149 2022-02-02 09:45:38
 

--- a/checkpoints/bestmodel.txt
+++ b/checkpoints/bestmodel.txt
@@ -1,2 +1,2 @@
-festive-peony-3193 epoch:149 2022-02-02 09:45:38
+dainty-dream-3224 epoch:125 2022-03-21 16:00:09
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -5,7 +5,7 @@ defaults:
     - _self_
     - trainer: default.yaml
     - model: default.yaml
-    - datamodule: deadtrees_combo_dataset_singleclass_rgbn.yaml
+    - datamodule: deadtrees_combo_dataset_multiclass_rgbn.yaml
     - callbacks: default.yaml
     - logger: wandb.yaml
 

--- a/configs/datamodule/deadtrees_combo_dataset_multiclass_rgbn.yaml
+++ b/configs/datamodule/deadtrees_combo_dataset_multiclass_rgbn.yaml
@@ -14,6 +14,5 @@ datamodule:
 
 model:
   network:
-    classes: 3
-    class_labels: ["background", "conifers", "deciduous"]
+    classes: ["background", "conifers", "deciduous"]
     in_channels: 4

--- a/configs/datamodule/deadtrees_combo_dataset_multiclass_rgbn.yaml
+++ b/configs/datamodule/deadtrees_combo_dataset_multiclass_rgbn.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+datamodule:
+  _target_: deadtrees.data.deadtreedata.DeadtreesDataModule
+  pattern: "train-combo-*.tar"
+  train_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+  val_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+  test_dataloader_conf:
+    batch_size: 32
+    num_workers: 2
+
+model:
+  network:
+    classes: 3
+    class_labels: ["background", "conifers", "deciduous"]
+    in_channels: 4

--- a/configs/datamodule/deadtrees_combo_dataset_singleclass_rgbn.yaml
+++ b/configs/datamodule/deadtrees_combo_dataset_singleclass_rgbn.yaml
@@ -14,5 +14,5 @@ datamodule:
 
 model:
   network:
-    classes: 2
+    classes: ["background", "deadtree"]
     in_channels: 4

--- a/configs/model/default.yaml
+++ b/configs/model/default.yaml
@@ -6,7 +6,7 @@ network:
     decoder_channels: [256, 128, 64, 32, 16]
     encoder_depth: 5
     encoder_weights: "imagenet"
-    losses: ["GDICE", "FOCAL", "BOUNDARY-RAMPED"]   # GDICE, FOCAL, BOUNDARY, BOUNDARY-RAMPED
+    losses: ["GDICE", "FOCAL", "BOUNDARY"]   # GDICE, FOCAL, BOUNDARY, BOUNDARY-RAMPED
 
 training:
     learning_rate: 0.0003 #3 #0.00015 #0.0001

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -20,3 +20,5 @@
 /predicted.2020
 /predicted_mosaic_2020.tif
 /processed.masks.2017
+/processed.lus.2017
+/processed.lus.2019

--- a/data/processed.lus.2017.dvc
+++ b/data/processed.lus.2017.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 07c6a9880e1b9d237cacaec1b7e40898.dir
+  size: 47028124740
+  nfiles: 11210
+  path: processed.lus.2017

--- a/data/processed.lus.2019.dvc
+++ b/data/processed.lus.2019.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e7700c6cafd6d3140afc916637ef54c6.dir
+  size: 54193516092
+  nfiles: 12918
+  path: processed.lus.2019

--- a/data/raw/shapefiles/.gitignore
+++ b/data/raw/shapefiles/.gitignore
@@ -4,3 +4,4 @@
 /deadtrees_area_2019
 /deadtrees_area_2017
 /deadtrees_2017
+/forestmask

--- a/data/raw/shapefiles/forestmask.dvc
+++ b/data/raw/shapefiles/forestmask.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: cfff5afb86673c56ef2ab0cabe3b5a84.dir
+  size: 43335161
+  nfiles: 5
+  path: forestmask

--- a/deadtrees/data/deadtreedata.py
+++ b/deadtrees/data/deadtreedata.py
@@ -161,9 +161,10 @@ def transform(
         )
         sample["image"] = transformed["image"].float()
         sample["mask"] = transformed["mask"].long()
-        sample["lu"] = transformed["lu"]  # .long()
+        sample["lu"] = transformed["lu"]
 
     sample["image"] = sample["image"][0:in_channels]
+    sample["lu"] = torch.tensor(sample["lu"], dtype=torch.long)
 
     if classes == 2:
         sample["mask"][sample["mask"] > 1] = 1

--- a/deadtrees/data/deadtreedata.py
+++ b/deadtrees/data/deadtreedata.py
@@ -94,8 +94,10 @@ def mask_decoder(data):
     return np.asarray(img)
 
 
-def sample_decoder(sample, img_suffix="rgbn.tif", msk_suffix="mask.tif"):
-    """Decode data (image, mask, stats) from sharded datastore"""
+def sample_decoder(
+    sample, img_suffix="rgbn.tif", msk_suffix="mask.tif", lu_suffix="lu.tif"
+):
+    """Decode data (image, mask, lu, stats) from sharded datastore"""
 
     assert img_suffix in sample, "Wrong image suffix provided"
 
@@ -106,6 +108,10 @@ def sample_decoder(sample, img_suffix="rgbn.tif", msk_suffix="mask.tif"):
 
     if msk_suffix in sample:
         sample[msk_suffix] = mask_decoder(sample[msk_suffix])
+
+    if lu_suffix in sample:
+        sample[lu_suffix] = mask_decoder(sample[lu_suffix])
+
     return sample
 
 
@@ -149,10 +155,13 @@ def transform(
     """Apply transform func to sample and modify channels and/ or classes as specified in training setup"""
     if transform_func:
         transformed = transform_func(
-            image=sample["image"].copy(), mask=sample["mask"].copy()
+            image=sample["image"].copy(),
+            mask=sample["mask"].copy(),
+            lu=sample["lu"].copy(),
         )
         sample["image"] = transformed["image"].float()
         sample["mask"] = transformed["mask"].long()
+        sample["lu"] = transformed["lu"]  # .long()
 
     sample["image"] = sample["image"][0:in_channels]
 
@@ -253,7 +262,7 @@ class DeadtreesDataModule(pl.LightningDataModule):
                 )
                 .shuffle(shuffle)
                 .map(sample_decoder)
-                .rename(image="rgbn.tif", mask="mask.tif", stats="txt")
+                .rename(image="rgbn.tif", mask="mask.tif", lu="lu.tif", stats="txt")
                 .map(
                     partial(
                         transform,
@@ -263,7 +272,7 @@ class DeadtreesDataModule(pl.LightningDataModule):
                         distmap=True,
                     )
                 )
-                .to_tuple("image", "mask", "distmap", "stats")
+                .to_tuple("image", "mask", "distmap", "lu", "stats")
             )
 
         self.train_data = build_dataset(

--- a/deadtrees/train.py
+++ b/deadtrees/train.py
@@ -68,7 +68,7 @@ def train(config: DictConfig) -> Optional[float]:
         )
     datamodule.setup(
         in_channels=config.model.network.in_channels,
-        classes=config.model.network.classes,
+        classes=len(config.model.network.classes),
     )
 
     # Init Lightning model

--- a/deadtrees/visualization/helper.py
+++ b/deadtrees/visualization/helper.py
@@ -1,9 +1,12 @@
 import logging
 from typing import Dict, List, Optional, Union
 
+import seaborn as sns
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import torch
 from deadtrees.data.deadtreedata import DeadtreeDatasetConfig
 from matplotlib.offsetbox import AnchoredText
@@ -99,7 +102,7 @@ def show(
     stats: Optional[Dict] = None,
     dpi: Optional[int] = 100,
     display: Optional[bool] = False,
-) -> np.ndarray:
+) -> Optional[np.ndarray]:
 
     items = {k: v for k, v in zip(["x", "y", "y_hat"], [x, y, y_hat]) if v is not None}
     items_orig = items.copy()
@@ -178,6 +181,48 @@ def show(
     fig.subplots_adjust(wspace=0, hspace=0)
     fig.tight_layout()
     out = fig2img(fig, dpi=dpi)
+    plt.close(fig)
+
+    if is_running_from_ipython():
+        if display:
+            render_image(out)
+            return None
+
+    return out
+
+
+def show_cm(
+    df_cm: pd.DataFrame,
+    df_cm_masked: pd.DataFrame,
+    *,
+    dpi: Optional[int] = 100,
+    display: Optional[bool] = False,
+) -> Optional[np.ndarray]:
+
+    fig, ax = plt.subplots(1, 2, figsize=(12, 6))
+
+    for i, df in enumerate([df_cm, df_cm_masked]):
+        sns.heatmap(
+            df,
+            ax=ax[i],
+            annot=True,
+            square=True,
+            cmap="rocket",
+            # xticklabels=self.classes,
+            # yticklabels=self.classes,
+            cbar=True,
+            cbar_kws={"shrink": 0.8},
+        )
+
+        ax[i].set_xlabel("Predicted")
+        ax[i].set_ylabel("Actual")
+
+    ax[0].title.set_text("Default")
+    ax[1].title.set_text("Forest Area Only")
+
+    fig.subplots_adjust(wspace=0, hspace=0)
+    fig.tight_layout()
+    out = fig2img(fig, dpi=dpi or 72)
     plt.close(fig)
 
     if is_running_from_ipython():

--- a/dvc.lock
+++ b/dvc.lock
@@ -116,7 +116,7 @@ stages:
       -o data/predicted_mosaic_2017.tif  data/predicted.2017/ortho_ms_2017_EPSG3044_*
     deps:
     - path: checkpoints/bestmodel.ckpt
-      md5: 0830f3f736486d7c9a3d5d59c64ef89d
+      md5: c59487c86e6f7bcb14a5c497a7f0089b
       size: 378716396
     - path: data/processed.images.2017
       md5: 66de96d201af5a47a09997691b992370.dir
@@ -124,12 +124,12 @@ stages:
       nfiles: 30489
     outs:
     - path: data/predicted.2017
-      md5: 2caf0e0722d7d48b1199f728f55b6b41.dir
-      size: 609342072
+      md5: ad21def827bf2a252138f6762597464e.dir
+      size: 601145568
       nfiles: 20827
     - path: data/predicted_mosaic_2017.tif
-      md5: 82ea7e83829548f3f5dbf9d895ada1c1
-      size: 847763504
+      md5: 33b53aa6241517496502ca1fe03401ce
+      size: 838497547
   inference@2019:
     cmd: mkdir -p data/predicted.2019; stdbuf -i0 -o0 -e0 python scripts/inference.py
       --all --nopreview -o data/predicted.2019 data/processed.images.2019; gdal_merge.py  -co
@@ -137,7 +137,7 @@ stages:
       -o data/predicted_mosaic_2019.tif  data/predicted.2019/ortho_ms_2019_EPSG3044_*
     deps:
     - path: checkpoints/bestmodel.ckpt
-      md5: 0830f3f736486d7c9a3d5d59c64ef89d
+      md5: c59487c86e6f7bcb14a5c497a7f0089b
       size: 378716396
     - path: data/processed.images.2019
       md5: 35c31b781cb0bdb19650329132d83d05.dir
@@ -145,12 +145,12 @@ stages:
       nfiles: 30489
     outs:
     - path: data/predicted.2019
-      md5: c0407b3307d72a1e9b2d03c9681fedab.dir
-      size: 484838541
+      md5: ff09ad567a42a10d1b8c5ff098d62136.dir
+      size: 483288492
       nfiles: 16227
     - path: data/predicted_mosaic_2019.tif
-      md5: dfdad6a91027357604d364c83aee6a51
-      size: 811939236
+      md5: c89513afe48839ffacd2e45421437aba
+      size: 810008817
   computestats:
     cmd: 'python scripts/computestats.py --frac 0.1 data/processed.images.2017   data/processed.images.2018   data/processed.images.2019  data/processed.images.2020 '
     deps:
@@ -177,25 +177,25 @@ stages:
     cmd: 'python scripts/computestats_inference.py data/predicted.2017   data/predicted.2018   data/predicted.2019  data/predicted.2020  '
     deps:
     - path: data/predicted.2017
-      md5: 2caf0e0722d7d48b1199f728f55b6b41.dir
-      size: 609342072
+      md5: ad21def827bf2a252138f6762597464e.dir
+      size: 601145568
       nfiles: 20827
     - path: data/predicted.2018
-      md5: 4a8d3690204b3b9f8ce22d0d294c5f5f.dir
-      size: 554987324
+      md5: 2152e803d1044ee771f3a19e35648d47.dir
+      size: 558479715
       nfiles: 19182
     - path: data/predicted.2019
-      md5: c0407b3307d72a1e9b2d03c9681fedab.dir
-      size: 484838541
+      md5: ff09ad567a42a10d1b8c5ff098d62136.dir
+      size: 483288492
       nfiles: 16227
     - path: data/predicted.2020
-      md5: b1fbe2f41bdf8506c77207bc48b8bc41.dir
-      size: 501850097
+      md5: 5919f87ca3378fbe295f3d3d575cd519.dir
+      size: 510695837
       nfiles: 16125
     outs:
     - path: data/predicted.stats.csv
-      md5: 456ba800c0711a8970fa9656c7541d8a
-      size: 1820536
+      md5: 8ee84bfe6481ebee2c9a711f1056e3b9
+      size: 1820942
   createtiles@2018:
     cmd: mkdir -p data/processed.images.2018; gdal_retile.py  -csv locations.csv  -v
       -ps 2048 2048 -co "TILED=YES" -co "COMPRESS=LZW" -co "PREDICTOR=2" -co "ALPHA=NO"
@@ -235,7 +235,7 @@ stages:
       -o data/predicted_mosaic_2018.tif  data/predicted.2018/ortho_ms_2018_EPSG3044_*
     deps:
     - path: checkpoints/bestmodel.ckpt
-      md5: 0830f3f736486d7c9a3d5d59c64ef89d
+      md5: c59487c86e6f7bcb14a5c497a7f0089b
       size: 378716396
     - path: data/processed.images.2018
       md5: cfa0adee6401f838f162a0510085becf.dir
@@ -243,12 +243,12 @@ stages:
       nfiles: 30489
     outs:
     - path: data/predicted.2018
-      md5: 4a8d3690204b3b9f8ce22d0d294c5f5f.dir
-      size: 554987324
+      md5: 2152e803d1044ee771f3a19e35648d47.dir
+      size: 558479715
       nfiles: 19182
     - path: data/predicted_mosaic_2018.tif
-      md5: dcb161619c72c210f09ee9100f2aff6f
-      size: 835391681
+      md5: 7b0ee5032be6beaa070e1d8325608618
+      size: 839265057
   inference@2020:
     cmd: mkdir -p data/predicted.2020; stdbuf -i0 -o0 -e0 python scripts/inference.py
       --all --nopreview -o data/predicted.2020 data/processed.images.2020; gdal_merge.py  -co
@@ -256,7 +256,7 @@ stages:
       -o data/predicted_mosaic_2020.tif  data/predicted.2020/ortho_ms_2020_EPSG3044_*
     deps:
     - path: checkpoints/bestmodel.ckpt
-      md5: 0830f3f736486d7c9a3d5d59c64ef89d
+      md5: c59487c86e6f7bcb14a5c497a7f0089b
       size: 378716396
     - path: data/processed.images.2020
       md5: 76d4daf0d9e69904a9370a0c74006d17.dir
@@ -264,12 +264,12 @@ stages:
       nfiles: 30489
     outs:
     - path: data/predicted.2020
-      md5: b1fbe2f41bdf8506c77207bc48b8bc41.dir
-      size: 501850097
+      md5: 5919f87ca3378fbe295f3d3d575cd519.dir
+      size: 510695837
       nfiles: 16125
     - path: data/predicted_mosaic_2020.tif
-      md5: 5fe6a9127327acd9bf2686053fdd62e2
-      size: 826975489
+      md5: 45191f0ce5c33892802086ebfe6d3dac
+      size: 836879273
   createmasks@2017:
     cmd: python scripts/createmasks.py  data/processed.images.2017  data/processed.masks.2017  data/raw/shapefiles/deadtrees_2017/deadtrees_2017.shp
     deps:
@@ -308,7 +308,7 @@ stages:
       md5: a0930762410178472817df1312b9004c
       size: 393915
     - path: data/dataset/train_2017
-      md5: cfac7705b8f9154e134ddb55b25257ec.dir
+      md5: 6cf366c7dff644b2633f8b0431150176.dir
       size: 213708800
       nfiles: 10
   createdataset@2019:
@@ -333,7 +333,7 @@ stages:
       md5: 64689003eea15a151ecf77c35382f806
       size: 2539254
     - path: data/dataset/train_2019
-      md5: 4306d82082d8493a5fc6c06ad3941e1f.dir
+      md5: 8d169211ce10dee5e3cacc87022b724a.dir
       size: 4167321600
       nfiles: 195
   createmasks@2019:
@@ -356,23 +356,23 @@ stages:
     cmd: python scripts/mergedatasets.py data/dataset/train_2017 data/dataset/train_2019
     deps:
     - path: data/dataset/train_2017
-      md5: cfac7705b8f9154e134ddb55b25257ec.dir
+      md5: 6cf366c7dff644b2633f8b0431150176.dir
       size: 213708800
       nfiles: 10
     - path: data/dataset/train_2019
-      md5: 4306d82082d8493a5fc6c06ad3941e1f.dir
+      md5: 8d169211ce10dee5e3cacc87022b724a.dir
       size: 4167321600
       nfiles: 195
     outs:
     - path: data/dataset/test
-      md5: a2cdcc4fce869836f53b86343b86342c.dir
+      md5: 586f2551d21df3186994c4059cf24336.dir
       size: 448788480
       nfiles: 21
     - path: data/dataset/train
-      md5: f7383adcd899f831abfd1f008384f5af.dir
+      md5: 4a011db15a6dd282ae442433665b4337.dir
       size: 3056035840
       nfiles: 143
     - path: data/dataset/val
-      md5: 987e2f69e2a5650b2700f7a611a878e6.dir
+      md5: 0ae195e6d30ac5e082e420affe7b911f.dir
       size: 876206080
       nfiles: 41

--- a/dvc.lock
+++ b/dvc.lock
@@ -287,13 +287,17 @@ stages:
       size: 629310300
       nfiles: 150
   createdataset@2017:
-    cmd: python scripts/createdataset.py  data/processed.images.2017  data/processed.masks.2017  data/dataset  --subdir
+    cmd: python scripts/createdataset.py  data/processed.images.2017  data/processed.masks.2017  data/processed.lus.2017  data/dataset  --subdir
       train_2017 --source_dim 2048 --tile_size 256 --format TIFF --stats stats_2017.csv
     deps:
     - path: data/processed.images.2017
       md5: 66de96d201af5a47a09997691b992370.dir
       size: 109902740888
       nfiles: 30489
+    - path: data/processed.lus.2017
+      md5: cd93e1d1eb4f857a9dab0cdc9e61c476.dir
+      size: 54193516092
+      nfiles: 12918
     - path: data/processed.masks.2017
       md5: 2e6d801d4c4e11563eda90d8085b7935.dir
       size: 629310300
@@ -305,20 +309,24 @@ stages:
         source_dim: 2048
     outs:
     - path: data/dataset/stats_2017.csv
-      md5: a0930762410178472817df1312b9004c
-      size: 393915
+      md5: c805b68642bcc296e28da8b326884848
+      size: 386040
     - path: data/dataset/train_2017
-      md5: 6cf366c7dff644b2633f8b0431150176.dir
-      size: 213708800
-      nfiles: 10
+      md5: e81f7940d0faff271da394321e311117.dir
+      size: 82698240
+      nfiles: 4
   createdataset@2019:
-    cmd: python scripts/createdataset.py  data/processed.images.2019  data/processed.masks.2019  data/dataset  --subdir
+    cmd: python scripts/createdataset.py  data/processed.images.2019  data/processed.masks.2019  data/processed.lus.2019  data/dataset  --subdir
       train_2019 --source_dim 2048 --tile_size 256 --format TIFF --stats stats_2019.csv
     deps:
     - path: data/processed.images.2019
       md5: 35c31b781cb0bdb19650329132d83d05.dir
       size: 144926802415
       nfiles: 30489
+    - path: data/processed.lus.2019
+      md5: e7700c6cafd6d3140afc916637ef54c6.dir
+      size: 54193516092
+      nfiles: 12918
     - path: data/processed.masks.2019
       md5: 83ce7ca88e1ed7fbf401d0d185ec261d.dir
       size: 4103103156
@@ -330,12 +338,12 @@ stages:
         source_dim: 2048
     outs:
     - path: data/dataset/stats_2019.csv
-      md5: 64689003eea15a151ecf77c35382f806
-      size: 2539254
+      md5: c4bdc60a6b48ccbf31bba9c7504c19fe
+      size: 2513851
     - path: data/dataset/train_2019
-      md5: 8d169211ce10dee5e3cacc87022b724a.dir
-      size: 4167321600
-      nfiles: 195
+      md5: 728a0796c7104bd7605a545436a961a3.dir
+      size: 1612994560
+      nfiles: 63
   createmasks@2019:
     cmd: python scripts/createmasks.py  data/processed.images.2019  data/processed.masks.2019  data/raw/shapefiles/deadtrees_2019/deadtrees_2019.shp
     deps:
@@ -356,23 +364,23 @@ stages:
     cmd: python scripts/mergedatasets.py data/dataset/train_2017 data/dataset/train_2019
     deps:
     - path: data/dataset/train_2017
-      md5: 6cf366c7dff644b2633f8b0431150176.dir
-      size: 213708800
-      nfiles: 10
+      md5: e81f7940d0faff271da394321e311117.dir
+      size: 82698240
+      nfiles: 4
     - path: data/dataset/train_2019
-      md5: 8d169211ce10dee5e3cacc87022b724a.dir
-      size: 4167321600
-      nfiles: 195
+      md5: 728a0796c7104bd7605a545436a961a3.dir
+      size: 1612994560
+      nfiles: 63
     outs:
     - path: data/dataset/test
-      md5: 586f2551d21df3186994c4059cf24336.dir
-      size: 448788480
-      nfiles: 21
+      md5: 3ff97b121f844527c47f56b64a0e9f9e.dir
+      size: 154163200
+      nfiles: 7
     - path: data/dataset/train
-      md5: 4a011db15a6dd282ae442433665b4337.dir
-      size: 3056035840
-      nfiles: 143
+      md5: 353b5f9560a93eac1d40c0338055850c.dir
+      size: 1181839360
+      nfiles: 46
     - path: data/dataset/val
-      md5: 0ae195e6d30ac5e082e420affe7b911f.dir
-      size: 876206080
-      nfiles: 41
+      md5: 585409c048c574f7cc9bf5e32176da5b.dir
+      size: 359690240
+      nfiles: 14

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -66,6 +66,7 @@ stages:
         python scripts/createdataset.py 
         data/processed.images.${item} 
         data/processed.masks.${item} 
+        data/processed.lus.${item} 
         data/dataset 
         --subdir train_${item}
         --source_dim ${source_dim}
@@ -75,6 +76,7 @@ stages:
       deps:
       - data/processed.images.${item}
       - data/processed.masks.${item} 
+      - data/processed.lus.${item} 
       params:
       - source_dim
       - createdataset.tile_size

--- a/scripts/createforestmasks.py
+++ b/scripts/createforestmasks.py
@@ -1,0 +1,222 @@
+# createmasks stage
+
+import argparse
+from functools import partial
+from pathlib import Path
+from typing import Iterable, Union
+
+import psutil
+from pygeos.set_operations import union
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import rioxarray
+import xarray as xr
+from shapely.geometry import Polygon
+from tqdm.contrib.concurrent import process_map
+
+
+def make_poly(coords: pd.Series) -> Polygon:
+    """Create Shapely polygon (a tile boundary) from x1,y1 and x2,y2 coordinates"""
+    xs = [coords[v] for v in "x1,x1,x2,x2,x1".split(",")]
+    ys = [coords[v] for v in "y1,y2,y2,y1,y1".split(",")]
+    return Polygon(zip(xs, ys))
+
+
+def _identify_empty(tile: Union[Path, str]) -> bool:
+    """Helper func for exclude_nodata_tiles"""
+
+    with xr.open_rasterio(tile).sel(band=1) as t:
+        # original check
+        # status = True if t.max().values - t.min().values > 0 else False
+        # check 2 (edge tiles with all white/ black are also detected)
+        return False if np.isin(t, [0, 255]).all() else True
+
+
+def exclude_nodata_tiles(
+    path: Iterable[Union[Path, str]],
+    tiles_df: gpd.GeoDataFrame,
+    workers: int,
+) -> gpd.GeoDataFrame:
+    """Identify tiles that only contain NoData (in parallel)"""
+
+    print(f"WORKERS: {workers}")
+
+    tile_names = sorted([Path(p) if isinstance(p, str) else p for p in path])
+
+    results = process_map(_identify_empty, tile_names, max_workers=workers, chunksize=1)
+
+    valid_d = dict([(t.name, r) for t, r in zip(tile_names, results)])
+
+    tiles_df["status"] = tiles_df.filename.map(valid_d)
+    # limit tiles to those with actual data (and delete status column afterwards)
+    return tiles_df[tiles_df.status == 1].drop("status", axis=1)
+
+
+def create_tile_grid_gdf(path: Union[Path, str], crs: str) -> gpd.GeoDataFrame:
+    """Convert gdal_tile split info file into geopandas dataframe"""
+
+    tiles_df = pd.read_csv(path, sep=";", header=None)
+    tiles_df.columns = ["filename", "x1", "x2", "y1", "y2"]
+    tiles_df["geometry"] = tiles_df.apply(make_poly, axis=1)
+    tiles_df = tiles_df.drop(["x1", "x2", "y1", "y2"], axis=1)
+    tiles_gpd = gpd.GeoDataFrame(tiles_df, crs=crs, geometry=tiles_df.geometry)
+    return tiles_gpd
+
+
+def split_groundtruth_data_by_tiles(
+    groundtruth: gpd.GeoDataFrame, tiles_df: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    """Split the oberserved dead tree areas into tile segments for faster downstream processing"""
+
+    union_gpd = gpd.overlay(tiles_df, groundtruth, how="intersection")
+
+    train_files = list(sorted(union_gpd.filename.value_counts().keys()))
+
+    tiles_with_groundtruth = tiles_df[tiles_df.filename.isin(train_files)]
+    return tiles_with_groundtruth, union_gpd  # union_gpd[union_gpd.id == 2]
+
+
+def _mask_tile(
+    tile_filename: str,
+    *,
+    groundtruth_df: gpd.GeoDataFrame,
+    crs: str,
+    inpath: Path,
+    outpath: Path,
+    simple: bool = False,
+) -> float:
+
+    image_tile_path = inpath / tile_filename
+    mask_tile_path = outpath / tile_filename
+
+    with rioxarray.open_rasterio(
+        image_tile_path, chunks={"band": 4, "x": 256, "y": 256}
+    ) as tile:
+        mask_orig = xr.ones_like(tile.load().sel(band=1, drop=True), dtype="uint8")
+        mask_orig.rio.set_crs(crs)
+        selection = groundtruth_df.loc[groundtruth_df.filename == tile_filename]
+
+        if simple:
+            # just use the geometry for clipping (single-class)
+            mask = mask_orig.rio.clip(
+                selection.geometry,
+                crs,
+                drop=False,
+                invert=False,
+                all_touched=True,
+                from_disk=True,
+            )
+
+        else:
+            # use type col from shapefile to create (multi-)classification masks
+
+            classes = [0, 1, 2]  # 0: non-class, 1: coniferous, 2: broadleaf
+
+            selection.loc[:, "type"] = pd.to_numeric(selection["type"])
+            masks = [mask_orig * 0]
+            for c in classes[1:]:
+                gdf = selection.loc[selection["type"] == c, :]
+
+                if len(gdf) > 0:
+                    mask = mask_orig.rio.clip(
+                        gdf.geometry,
+                        crs,
+                        drop=False,
+                        invert=False,
+                        all_touched=True,
+                        from_disk=True,
+                    )
+                else:
+                    mask = mask_orig * 0
+                masks.append(mask)
+            mask = xr.concat(masks, pd.Index(classes, name="classes")).argmax(
+                dim="classes"
+            )
+
+        mask.astype("uint8").rio.to_raster(mask_tile_path, tiled=True)
+        mask_sum = np.count_nonzero(mask.values)  # just for checks
+    return mask_sum
+
+
+def create_tile_mask_geotiffs(
+    tiles_df_train: gpd.GeoDataFrame, workers: int, **kwargs
+) -> None:
+    """Create binary mask geotiffs"""
+    process_map(
+        partial(_mask_tile, **kwargs),
+        tiles_df_train.filename.values,
+        max_workers=workers,
+        chunksize=1,
+    )
+
+
+def create_masks(
+    indir: Path,
+    outdir: Path,
+    shpfile: Path,
+    workers: int,
+) -> None:
+    """
+    Stage 1: produce masks for training tiles
+    """
+
+    # load domain shape files and use its crs for the entire script
+    groundtruth = gpd.read_file(shpfile).explode()
+    crs = groundtruth.crs  # reference crs
+
+    tiles_df = create_tile_grid_gdf(indir / "locations.csv", crs)
+    tiles_df = exclude_nodata_tiles(
+        sorted(indir.glob("*.tif")),
+        tiles_df,
+        workers,
+    )
+    print(f"len2: {len(tiles_df)}")
+    tiles_df.to_file("locations.shp")
+
+    tiles_df_train, groundtruth_df = split_groundtruth_data_by_tiles(
+        groundtruth, tiles_df
+    )
+
+    create_tile_mask_geotiffs(
+        tiles_df_train,
+        workers,
+        groundtruth_df=groundtruth_df,
+        crs=crs,
+        inpath=indir,
+        outpath=outdir,
+        simple=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("indir", type=Path)
+    parser.add_argument("outdir", type=Path)
+    parser.add_argument("shpfile", type=Path)
+
+    num_cores = psutil.cpu_count(logical=False)
+
+    parser.add_argument(
+        "--workers",
+        dest="workers",
+        type=int,
+        default=num_cores,
+        help="number of workers for parallel execution [def: %(default)s]",
+    )
+
+    args = parser.parse_args()
+
+    Path(args.outdir).mkdir(parents=True, exist_ok=True)
+
+    create_masks(
+        args.indir,
+        args.outdir,
+        args.shpfile,
+        args.workers,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if not MODEL_CHECKPOINT_PATH.exists():
 
 # extra package dependencies
 EXTRAS = {
-    "train": ["wandb"],
+    "train": ["wandb", "seaborn"],
     "preprocess": [
         "gdal",
         "pygeos",


### PR DESCRIPTION
This PR adds a forest mask to the `webdataset`. Currently it's only used to (optionally) limit the pixels that are evaluated for a confusion matrix (which was also added to the W&B logging)... The model reports class-specific confusion matrices at validation and test time for all pixels in the evaluation data and also for the forest masked subset.

The model is still trained end-to-end (i.e. the forest mask is not used in limit trainman data)!